### PR TITLE
Added anonymous auth option

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -160,7 +160,7 @@ module mcp './app/mcp.bicep' = {
       AzureWebJobsFeatureFlags: 'EnableMcpCustomHandlerPreview'
     }
     virtualNetworkSubnetId: vnetEnabled ? serviceVirtualNetwork.outputs.appSubnetID : ''
-    // Authorization parameters (only when Entra ID auth is enabled)
+    // Authorization parameters (only when built-in MCP auth is enabled)
     authClientId: useBuiltInMcpAuth ? entraApp.outputs.applicationId : ''
     authIdentifierUri: useBuiltInMcpAuth ? entraApp.outputs.identifierUri : ''
     authExposedScopes: useBuiltInMcpAuth ? entraApp.outputs.exposedScopes : []
@@ -279,7 +279,7 @@ output SERVICE_MCP_NAME string = mcp.outputs.SERVICE_MCP_NAME
 output SERVICE_MCP_DEFAULT_HOSTNAME string = mcp.outputs.SERVICE_MCP_DEFAULT_HOSTNAME
 output AZURE_FUNCTION_NAME string = mcp.outputs.SERVICE_MCP_NAME
 
-// Entra App outputs (only when Entra ID auth is enabled)
+// Entra App outputs (using the initial app for core properties)
 output ENTRA_APPLICATION_ID string = useBuiltInMcpAuth ? entraApp.outputs.applicationId : ''
 output ENTRA_APPLICATION_OBJECT_ID string = useBuiltInMcpAuth ? entraApp.outputs.applicationObjectId : ''
 output ENTRA_SERVICE_PRINCIPAL_ID string = useBuiltInMcpAuth ? entraApp.outputs.servicePrincipalId : ''

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -22,6 +22,9 @@
     },
     "tokenExchangeAudience": {
       "value": "${TOKEN_EXCHANGE_AUDIENCE}"
+    },
+    "anonymousServerAuth": {
+      "value": "${ANONYMOUS_SERVER_AUTH}"
     }
   }
 }


### PR DESCRIPTION
Made changes so you can specify server to have anonymous auth by setting the environment variable like this  `azd env set ANONYMOUS_SERVER_AUTH true` before running `azd up`. If you do this, the get_user_info tool no longer works because there's no logged in user. 

Also, if you set the auth to anonymous you shouldn't have to set PRE_AUTHORIZED_CLIENT_IDS since that's only needed for built-in MCP auth.

If you don't set the env variable, the default is built-in MCP auth.